### PR TITLE
docs: fix incorrect package name, and typo in Edge view engine docs for indonesian version

### DIFF
--- a/src/content/docs/docs/view-engine/edge.mdx
+++ b/src/content/docs/docs/view-engine/edge.mdx
@@ -2,7 +2,7 @@
 title: Edge
 ---
 
-`@gaman/edge` is the **official middleware** for integrating [Edge Engine](http://edgejs.dev) as a **view engine** in the **GamanJS** framework.  
+`@gaman/edge` is the **official middleware** for integrating [Edge Engine](https://edgejs.dev) as a **view engine** in the **GamanJS** framework.
 With this, you can render `.edge` template files (or other extensions) directly from controllers/handlers using GamanJS's built-in view system.
 
 ## Installation
@@ -10,7 +10,7 @@ With this, you can render `.edge` template files (or other extensions) directly 
 import { PackageManagers } from "starlight-package-managers";
 
 <PackageManagers
-  pkg="@gaman/edge edge"
+  pkg="@gaman/edge edge.js"
   pkgManagers={["npm", "pnpm", "yarn", "bun"]}
   type="install"
 />
@@ -28,7 +28,7 @@ import { edge } from "@gaman/edge";
 defineBootstrap((app) => {
   app.mount(
     edge({
-      viewPath: "src/views", 
+      viewPath: "src/views",
     })
   );
 });

--- a/src/content/docs/id/docs/view-engine/edge.mdx
+++ b/src/content/docs/id/docs/view-engine/edge.mdx
@@ -2,7 +2,7 @@
 title: Edge
 ---
 
-`@gaman/edge` adalah **middleware resmi** untuk integrasi [Edge Engine](http://edgejs.dev) sebagai **view engine** di framework **GamanJS**.  
+`@gaman/edge` adalah **middleware resmi** untuk integrasi [Edge Engine](https://edgejs.dev) sebagai **view engine** di framework **GamanJS**.
 Dengan ini Anda bisa merender file template `.edge` (atau ekstensi lain) langsung dari controller/handler menggunakan sistem view bawaan GamanJS.
 
 ## Install
@@ -10,7 +10,7 @@ Dengan ini Anda bisa merender file template `.edge` (atau ekstensi lain) langsun
 import { PackageManagers } from "starlight-package-managers";
 
 <PackageManagers
-  pkg="@gaman/edge edge"
+  pkg="@gaman/edge edge.js"
   pkgManagers={["npm", "pnpm", "yarn", "bun"]}
   type="install"
 />
@@ -29,7 +29,7 @@ import { edge } from "@gaman/edge";
 defineBootstrap((app) => {
   app.mount(
     edge({
-      viewPath: "src/views", 
+      viewPath: "src/views",
     })
   );
 });
@@ -107,4 +107,4 @@ defineBootstrap(async (app) => {
 
 ---
 
-> Silakan baca dokumentasi lebih detail tentang [EJS (Embedded JavaScript Templates)](https://ejs.co)
+> Silakan baca dokumentasi lebih detail tentang [Edge.js](https://edgejs.dev)


### PR DESCRIPTION
## 🎯 What’s Changed?
Fixing incorrect package name for edge view engine it should be installed as edge.js but in docs says edge and that's completely different packages

## 🛠 Type of Change
- [x] 📚 Documentation / Comments

## ✅ Checklist

- [x] Tested on **Desktop**
- [x] Tested on **Mobile / Responsive**
- [x] No **console.log** or unused code left behind
- [x] Self-reviewed (not blindly pushed)
- [x] Does not break other components or pages